### PR TITLE
Add mock server functionality

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -23,6 +23,7 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'com.google.code.gson:gson:2.10.1'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
@@ -30,4 +31,8 @@ dependencies {
 
 springBoot {
 	mainClass = 'com.blakekhan.httpmocker.server.ServerApplication'
+}
+
+test {
+	useJUnitPlatform()
 }

--- a/server/src/main/java/com/blakekhan/httpmocker/server/ServerApplication.java
+++ b/server/src/main/java/com/blakekhan/httpmocker/server/ServerApplication.java
@@ -1,5 +1,7 @@
 package com.blakekhan.httpmocker.server;
 
+import com.blakekhan.httpmocker.server.mock.service.MockConfigService;
+import java.io.File;
 import java.util.logging.Logger;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
@@ -14,8 +16,10 @@ public class ServerApplication implements ApplicationRunner {
 
 	private static final Logger LOGGER = Logger.getLogger(ServerApplication.class.getName());
 
+	private static final String ARG_DISCOVER_MODE = "mode_discover";
 	private static final String ARG_NAME_TARGET_HOST = "target_host";
 	private static final String ARG_NAME_TARGET_PORT = "target_port";
+	private static final String ARG_MOCK_CONFIG_LOCATION = "mock_config_file"; // full path including filename
 
 	public static void main(String[] args) {
 		SpringApplication.run(ServerApplication.class, args);
@@ -23,23 +27,42 @@ public class ServerApplication implements ApplicationRunner {
 
 	@Override
 	public void run(ApplicationArguments args) throws Exception {
-		if (!args.containsOption(ARG_NAME_TARGET_HOST) || !args.containsOption(ARG_NAME_TARGET_PORT)) {
-			LOGGER.severe("Must run with parameters %s and %s".formatted(ARG_NAME_TARGET_HOST, ARG_NAME_TARGET_PORT));
-			System.exit(-1);
-		}
+		if (args.containsOption(ARG_DISCOVER_MODE)) {
+			if (!args.containsOption(ARG_NAME_TARGET_HOST) || !args.containsOption(ARG_NAME_TARGET_PORT)) {
+				LOGGER.severe("Must run with parameters %s and %s for discover mode".formatted(ARG_NAME_TARGET_HOST, ARG_NAME_TARGET_PORT));
+				System.exit(-1);
+			}
 
-		LOGGER.info("Configured target host: %s".formatted(targetHost(args)));
-		LOGGER.info("Configured target port: %d".formatted(targetPort(args)));
+			LOGGER.info("Configured target host: %s".formatted(targetHost(args)));
+			LOGGER.info("Configured target port: %d".formatted(targetPort(args)));
+		} else {
+			if (!args.containsOption(ARG_MOCK_CONFIG_LOCATION)) {
+				LOGGER.severe("Must run with parameter %s or use %s for discover mode.".formatted(ARG_MOCK_CONFIG_LOCATION, ARG_DISCOVER_MODE));
+				System.exit(-1);
+			}
+			LOGGER.info("Running in mock mode.");
+		}
 	}
 
 	@Bean
 	public String targetHost(ApplicationArguments args) {
+		if (args.getOptionValues(ARG_NAME_TARGET_HOST) == null) {
+			return "";
+		}
 		return args.getOptionValues(ARG_NAME_TARGET_HOST).get(0);
 	}
 
 	@Bean
 	public int targetPort(ApplicationArguments args) {
+		if (args.getOptionValues(ARG_NAME_TARGET_PORT) == null) {
+			return -1;
+		}
 		return Integer.parseInt(args.getOptionValues(ARG_NAME_TARGET_PORT).get(0));
+	}
+
+	@Bean
+	public File mockedEndpointsFile(ApplicationArguments args) {
+		return new File(args.getOptionValues(ARG_MOCK_CONFIG_LOCATION).get(0));
 	}
 
 }

--- a/server/src/main/java/com/blakekhan/httpmocker/server/discover/DiscoverController.java
+++ b/server/src/main/java/com/blakekhan/httpmocker/server/discover/DiscoverController.java
@@ -5,6 +5,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.net.URISyntaxException;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@ConditionalOnProperty("mode_discover")
 public class DiscoverController {
 
   public static final String ENDPOINT_DISCOVER = "/discover";

--- a/server/src/main/java/com/blakekhan/httpmocker/server/mock/MockController.java
+++ b/server/src/main/java/com/blakekhan/httpmocker/server/mock/MockController.java
@@ -1,0 +1,38 @@
+package com.blakekhan.httpmocker.server.mock;
+
+import com.blakekhan.httpmocker.server.mock.config.MockedResponse;
+import com.blakekhan.httpmocker.server.mock.service.MockConfigService;
+import java.util.Map;
+import java.util.Optional;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class MockController {
+
+  private final MockConfigService mockConfigService;
+
+  public MockController(@Autowired MockConfigService mockConfigService) {
+    this.mockConfigService = mockConfigService;
+  }
+
+  @RequestMapping(value = "/{*endpoint}")
+  public ResponseEntity<String> handle(@PathVariable String endpoint, @RequestHeader Map<String, String> headers, @RequestParam Map<String,String> requestParams) {
+    Optional<MockedResponse> optionalResponse = mockConfigService.getMockedResponseFor(endpoint, headers, requestParams);
+    if (optionalResponse.isEmpty()) {
+      return new ResponseEntity<>("No configured mocked response fits this request.", HttpStatus.NOT_FOUND);
+    }
+
+    MockedResponse mockedResponse = optionalResponse.get();
+    ResponseEntity.BodyBuilder builder = ResponseEntity.status(mockedResponse.getResponseHttpStatus().get());
+    mockedResponse.getResponseHeaders().forEach(builder::header);
+    return builder.body(mockedResponse.getBody());
+  }
+
+}

--- a/server/src/main/java/com/blakekhan/httpmocker/server/mock/config/MockedEndpoint.java
+++ b/server/src/main/java/com/blakekhan/httpmocker/server/mock/config/MockedEndpoint.java
@@ -1,0 +1,20 @@
+package com.blakekhan.httpmocker.server.mock.config;
+
+import java.util.List;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.http.HttpMethod;
+
+@NoArgsConstructor
+@Data
+public class MockedEndpoint {
+
+  private String endpoint; // e.g. /hello-world
+  public String httpMethod; // e.g. GET
+  private List<MockedResponse> responses;
+
+  public HttpMethod getHttpMethod() {
+    return HttpMethod.valueOf(httpMethod);
+  }
+
+}

--- a/server/src/main/java/com/blakekhan/httpmocker/server/mock/config/MockedEndpoints.java
+++ b/server/src/main/java/com/blakekhan/httpmocker/server/mock/config/MockedEndpoints.java
@@ -1,0 +1,19 @@
+package com.blakekhan.httpmocker.server.mock.config;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import java.io.InputStreamReader;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.List;
+
+public class MockedEndpoints {
+
+  private static final Gson GSON = new Gson();
+
+  public static List<MockedEndpoint> fromInputStreamReader(InputStreamReader isr) {
+    Type listType = new TypeToken<ArrayList<MockedEndpoint>>(){}.getType();
+    return GSON.fromJson(isr, listType);
+  }
+
+}

--- a/server/src/main/java/com/blakekhan/httpmocker/server/mock/config/MockedResponse.java
+++ b/server/src/main/java/com/blakekhan/httpmocker/server/mock/config/MockedResponse.java
@@ -1,0 +1,66 @@
+package com.blakekhan.httpmocker.server.mock.config;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.logging.Logger;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.InvalidMediaTypeException;
+import org.springframework.http.MediaType;
+
+@NoArgsConstructor
+@Data
+public class MockedResponse implements Comparable<MockedResponse> {
+
+  private String name; // Some identifier
+  private int responseHttpCode; // Status code to return
+  private Map<String, String> queryParameters = Collections.emptyMap(); // Query (request) params to match (must be exact match)
+  private Map<String, String> requestHeaders = Collections.emptyMap(); // Headers to match
+  private Map<String, String> responseHeaders = Collections.emptyMap(); // Headers to return
+  private String body; // Body to return
+
+  public Optional<HttpStatus> getResponseHttpStatus() {
+    return Optional.ofNullable(HttpStatus.resolve(responseHttpCode));
+  }
+
+  public boolean doQueryParamsMatch(Map<String, String> input) {
+    if (queryParameters.isEmpty() && input.isEmpty()) {
+      return true;
+    }
+
+    return queryParameters.equals(input);
+  }
+
+  public boolean doHeadersMatch(Map<String, String> input) {
+    for (Entry<String, String> entry : requestHeaders.entrySet()) {
+      String val = input.getOrDefault(entry.getKey(), null);
+
+      if (val == null && entry.getValue() != null) {
+        return false;
+      }
+
+      if (entry.getValue() == null && val != null) {
+        return false;
+      }
+
+      if (val != null && !val.equals(entry.getValue())) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  @Override
+  public int compareTo(MockedResponse o) {
+    int result = Integer.compare(o.getRequestHeaders().size(), requestHeaders.size());
+    if (result == 0) {
+      result = Integer.compare(o.getQueryParameters().size(), queryParameters.size());
+    }
+    return result;
+  }
+}

--- a/server/src/main/java/com/blakekhan/httpmocker/server/mock/service/MockConfigService.java
+++ b/server/src/main/java/com/blakekhan/httpmocker/server/mock/service/MockConfigService.java
@@ -1,0 +1,71 @@
+package com.blakekhan.httpmocker.server.mock.service;
+
+import com.blakekhan.httpmocker.server.mock.config.MockedEndpoint;
+import com.blakekhan.httpmocker.server.mock.config.MockedEndpoints;
+import com.blakekhan.httpmocker.server.mock.config.MockedResponse;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.logging.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class MockConfigService {
+
+  private static final Logger LOGGER = Logger.getLogger(MockConfigService.class.getName());
+
+  private final File mockedEndpointsFile;
+  private final List<MockedEndpoint> endpoints;
+
+  public MockConfigService(@Autowired File mockedEndpointsFile) {
+    this.mockedEndpointsFile = mockedEndpointsFile;
+    this.endpoints = new ArrayList<>();
+    try {
+      loadFile();
+    } catch (FileNotFoundException ignored) {
+    }
+  }
+
+  private void loadFile() throws FileNotFoundException {
+    if (!mockedEndpointsFile.exists()) {
+      LOGGER.severe(String.format("Mocked endpoints file at %s does not exist!", mockedEndpointsFile.getAbsolutePath()));
+      System.exit(-1);
+    }
+
+    this.endpoints.addAll(MockedEndpoints.fromInputStreamReader(new InputStreamReader(new FileInputStream(mockedEndpointsFile))));
+    LOGGER.info(String.format("Loaded %s mocked endpoints.", endpoints.size()));
+    for (MockedEndpoint endpoint : endpoints) {
+      LOGGER.info(String.format("Endpoint %s has %d configured responses.", endpoint.getEndpoint(), endpoint.getResponses().size()));
+    }
+  }
+
+  private Optional<MockedEndpoint> getMockedEndpointFor(String path) {
+    return endpoints.stream()
+        .filter(e -> e.getEndpoint().equalsIgnoreCase(path))
+        .findFirst();
+  }
+
+  public Optional<MockedResponse> getMockedResponseFor(String path, Map<String, String> requestHeaders, Map<String, String> requestParams) {
+    Optional<MockedEndpoint> optionalEndpoint = getMockedEndpointFor(path);
+
+    LOGGER.info(String.format("Finding response for endpoint %s, headers %s, params %s.", path, requestHeaders, requestParams));
+
+    if (optionalEndpoint.isEmpty()) {
+      return Optional.empty();
+    }
+
+    MockedEndpoint endpoint = optionalEndpoint.get();
+    return endpoint.getResponses().stream()
+        .sorted()
+        .filter(resp -> resp.doQueryParamsMatch(requestParams))
+        .filter(resp -> resp.doHeadersMatch(requestHeaders))
+        .findFirst();
+  }
+
+}

--- a/server/src/test/java/com/blakekhan/httpmocker/server/mock/config/MockedEndpointsTest.java
+++ b/server/src/test/java/com/blakekhan/httpmocker/server/mock/config/MockedEndpointsTest.java
@@ -1,0 +1,55 @@
+package com.blakekhan.httpmocker.server.mock.config;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.List;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+
+public class MockedEndpointsTest {
+
+  @Test
+  public void testFromInputStreamReader() throws IOException {
+    File endpointsFile = new File("src/test/resources/endpoints.json");
+    InputStreamReader reader = new InputStreamReader(new FileInputStream(endpointsFile));
+    List<MockedEndpoint> list = MockedEndpoints.fromInputStreamReader(reader);
+
+    Assertions.assertEquals(2, list.size());
+    List<MockedResponse> responses = list.get(0).getResponses();
+
+    Assertions.assertEquals("/hello-world", list.get(0).getEndpoint());
+    Assertions.assertEquals(HttpMethod.GET, list.get(0).getHttpMethod());
+
+    Assertions.assertEquals("Match no query or header", responses.get(0).getName());
+    Assertions.assertEquals(200, responses.get(0).getResponseHttpCode());
+    Assertions.assertTrue(responses.get(0).getQueryParameters().isEmpty());
+    Assertions.assertTrue(responses.get(0).getRequestHeaders().isEmpty());
+    Assertions.assertEquals("Response 1", responses.get(0).getResponseHeaders().get("response-name"));
+    Assertions.assertEquals("{\"text\": \"this is a sample response body 1\"}", responses.get(0).getBody());
+
+    Assertions.assertEquals("Only Query Param Match", responses.get(1).getName());
+    Assertions.assertEquals(200, responses.get(1).getResponseHttpCode());
+    Assertions.assertEquals("bob", responses.get(1).getQueryParameters().get("name"));
+    Assertions.assertTrue(responses.get(1).getRequestHeaders().isEmpty());
+    Assertions.assertEquals("Response 2", responses.get(1).getResponseHeaders().get("response-name"));
+    Assertions.assertEquals("{\"text\": \"this is a sample response body 2\"}", responses.get(1).getBody());
+
+    Assertions.assertEquals("Only Header Match", responses.get(2).getName());
+    Assertions.assertEquals(200, responses.get(2).getResponseHttpCode());
+    Assertions.assertEquals("abc", responses.get(2).getRequestHeaders().get("match-me"));
+    Assertions.assertTrue(responses.get(2).getQueryParameters().isEmpty());
+    Assertions.assertEquals("Response 3", responses.get(2).getResponseHeaders().get("response-name"));
+    Assertions.assertEquals("{\"text\": \"this is a sample response body 3\"}", responses.get(2).getBody());
+
+    Assertions.assertEquals("Both Query and Header Match", responses.get(3).getName());
+    Assertions.assertEquals(200, responses.get(3).getResponseHttpCode());
+    Assertions.assertEquals("abc", responses.get(3).getRequestHeaders().get("match-me"));
+    Assertions.assertEquals("bob", responses.get(1).getQueryParameters().get("name"));
+    Assertions.assertEquals("Response 4", responses.get(3).getResponseHeaders().get("response-name"));
+    Assertions.assertEquals("{\"text\": \"this is a sample response body 4\"}", responses.get(3).getBody());
+  }
+
+}

--- a/server/src/test/resources/endpoints.json
+++ b/server/src/test/resources/endpoints.json
@@ -1,0 +1,72 @@
+[
+  {
+    "endpoint": "/hello-world",
+    "httpMethod": "GET",
+    "responses": [
+      {
+        "name": "Match no query or header",
+        "responseHttpCode": 200,
+        "queryParameters": {},
+        "requestHeaders": {},
+        "responseHeaders": {
+          "response-name": "Response 1"
+        },
+        "body": "{\"text\": \"this is a sample response body 1\"}"
+      },
+      {
+        "name": "Only Query Param Match",
+        "responseHttpCode": 200,
+        "queryParameters": {
+          "name": "bob"
+        },
+        "requestHeaders": {},
+        "responseHeaders": {
+          "response-name": "Response 2"
+        },
+        "body": "{\"text\": \"this is a sample response body 2\"}"
+      },
+      {
+        "name": "Only Header Match",
+        "responseHttpCode": 200,
+        "queryParameters": {},
+        "requestHeaders": {
+          "match-me": "abc"
+        },
+        "responseHeaders": {
+          "response-name": "Response 3"
+        },
+        "body": "{\"text\": \"this is a sample response body 3\"}"
+      },
+      {
+        "name": "Both Query and Header Match",
+        "responseHttpCode": 200,
+        "queryParameters": {
+          "name": "bob"
+        },
+        "requestHeaders": {
+          "match-me": "abc"
+        },
+        "responseHeaders": {
+          "response-name": "Response 4"
+        },
+        "body": "{\"text\": \"this is a sample response body 4\"}"
+      }
+    ]
+  },
+  {
+    "endpoint": "/hello/world",
+    "httpMethod": "GET",
+    "responses": [
+      {
+        "name": "Match no query or header",
+        "responseHttpCode": 200,
+        "queryParameters": {},
+        "requestHeaders": {},
+        "responseHeaders": {
+          "response-name": "Response 5"
+        },
+        "body": "{\"text\": \"this is a sample response body 5\"}"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
Requires JDK 17.

From the server directory, compile with `./gradlew build`

Two ways to start server:

1. In discovery mode: `java -jar build/libs/server-0.0.1-SNAPSHOT.jar --target_host=reqres.in --target_port=443`
2. In mocking mode: `java -jar build/libs/server-0.0.1-SNAPSHOT.jar --mock_config_file=src/test/resources/endpoints.json` (replace file path with actual file path)

Example endpoint config file:

```json
[
  {
    "endpoint": "/hello-world",
    "httpMethod": "GET",
    "responses": [
      {
        "name": "Match no query or header",
        "responseHttpCode": 200,
        "queryParameters": {},
        "requestHeaders": {},
        "responseHeaders": {
          "response-name": "Response 1"
        },
        "body": "{\"text\": \"this is a sample response body 1\"}"
      },
      {
        "name": "Only Query Param Match",
        "responseHttpCode": 200,
        "queryParameters": {
          "name": "bob"
        },
        "requestHeaders": {},
        "responseHeaders": {
          "response-name": "Response 2"
        },
        "body": "{\"text\": \"this is a sample response body 2\"}"
      },
      {
        "name": "Only Header Match",
        "responseHttpCode": 200,
        "queryParameters": {},
        "requestHeaders": {
          "match-me": "abc"
        },
        "responseHeaders": {
          "response-name": "Response 3"
        },
        "body": "{\"text\": \"this is a sample response body 3\"}"
      },
      {
        "name": "Both Query and Header Match",
        "responseHttpCode": 200,
        "queryParameters": {
          "name": "bob"
        },
        "requestHeaders": {
          "match-me": "abc"
        },
        "responseHeaders": {
          "response-name": "Response 4"
        },
        "body": "{\"text\": \"this is a sample response body 4\"}"
      }
    ]
  },
  {
    "endpoint": "/hello/world",
    "httpMethod": "GET",
    "responses": [
      {
        "name": "Match no query or header",
        "responseHttpCode": 200,
        "queryParameters": {},
        "requestHeaders": {},
        "responseHeaders": {
          "response-name": "Response 5"
        },
        "body": "{\"text\": \"this is a sample response body 5\"}"
      }
    ]
  }
]
```

Here you can see that for each endpoint, you can configure an unlimited number of responses. Responses will be selected by matching endpoint name, request headers, and request parameters. Request parameters must be an exact match, but request headers will match by closest to exact match. The name fields are for UI usage.

Example requests

```
blake@Blakes-MacBook-Pro-2 server % curl  "http://localhost:8080/hello-world"                           
{"text": "this is a sample response body 1"}%                                                                                                                                        blake@Blakes-MacBook-Pro-2 server % curl  "http://localhost:8080/hello-world?name=bob"                  
{"text": "this is a sample response body 2"}%                                                                                                                                        blake@Blakes-MacBook-Pro-2 server % curl -H "match-me:abc" "http://localhost:8080/hello-world"          
{"text": "this is a sample response body 3"}%                                                                                                                                        blake@Blakes-MacBook-Pro-2 server % curl -H "match-me:abc"  "http://localhost:8080/hello-world?name=bob"
{"text": "this is a sample response body 4"}%        
blake@Blakes-MacBook-Pro-2 server % curl  "http://localhost:8080/hello/world"                           
{"text": "this is a sample response body 5"}%     
```
